### PR TITLE
Fix run spaceranger on multiple samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 work/
 data/
 results/
+log/
+reports/
 .DS_Store
 testing/
 testing*

--- a/subworkflows/local/spaceranger.nf
+++ b/subworkflows/local/spaceranger.nf
@@ -20,11 +20,10 @@ workflow SPACERANGER {
     //
     ch_reference = Channel.empty()
     if (params.spaceranger_reference) {
-        ch_reference = Channel
-            .fromPath ( params.spaceranger_reference, type: "dir", checkIfExists: true )
+        ch_reference = file(params.spaceranger_reference, type: "dir", checkIfExists: true)
     } else {
         address = "https://cf.10xgenomics.com/supp/spatial-exp/refdata-gex-GRCh38-2020-A.tar.gz"
-        ch_reference = SPACERANGER_DOWNLOAD_REFERENCE ( address ).reference
+        ch_reference = SPACERANGER_DOWNLOAD_REFERENCE ( address ).reference.collect()
     }
 
     //
@@ -32,8 +31,7 @@ workflow SPACERANGER {
     //
     ch_probeset = Channel.empty()
     if (params.spaceranger_probeset) {
-        ch_probeset = Channel
-            .fromPath ( params.spaceranger_probeset, checkIfExists: true )
+        ch_probeset = file( params.spaceranger_probeset, checkIfExists: true )
     } else {
         ch_probeset = file ( 'EMPTY_PROBESET' )
     }


### PR DESCRIPTION
<!--
# nf-core/spatialtranscriptomics pull request

Many thanks for contributing to nf-core/spatialtranscriptomics!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/spatialtranscriptomics/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- ~~[ ] If you've fixed a bug or added code that should be tested, add tests!~~
- ~~[ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/spatialtranscriptomics/tree/master/.github/CONTRIBUTING.md)~~
- ~~[ ] If necessary, also make a PR on the nf-core/spatialtranscriptomics _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.~~
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- ~~[ ] Usage Documentation in `docs/usage.md` is updated.~~
- ~~[ ] Output Documentation in `docs/output.md` is updated.~~
- [ ] `CHANGELOG.md` is updated.
- ~~[ ] `README.md` is updated (including new tool citations and authors/contributors).~~


When multiple samples were specified in the samplesheet, only the first would run, because the spaceranger reference was a FIFO channel that would be exhausted after the first sample. This PR turns the reference into a value that is reused for all samples. 
